### PR TITLE
Fix DeprecationWarning

### DIFF
--- a/api_generator/yang_generator/common.py
+++ b/api_generator/yang_generator/common.py
@@ -165,11 +165,6 @@ def convert_to_reStructuredText(yang_text):
     reSt = yang_text
     if reSt is not None and len(reSt) > 0:
         reSt = yang_text.replace('\\', '\\\\')
-        reSt = reSt.replace(':', '\:')
-        reSt = reSt.replace('_', '\_')
-        reSt = reSt.replace('-', '\-')
-        reSt = reSt.replace('*', '\*')
-        reSt = reSt.replace('|', '\|')
     return reSt
 
 def is_config_stmt(stmt):

--- a/api_generator/yang_generator/printer/doc/doc_printer.py
+++ b/api_generator/yang_generator/printer/doc/doc_printer.py
@@ -275,11 +275,11 @@ class DocPrinter(object):
             parent_list.append(parent)
             parent = parent.owner
 
-        clazz_hierarchy = ['Class Hierarchy \:']
+        clazz_hierarchy = ['Class Hierarchy :']
         if len(parent_list) > 0:
             for parent in reversed(parent_list):
                 if not clazz_hierarchy[0][-1:] == ':':
-                    clazz_hierarchy.append(' \>')
+                    clazz_hierarchy.append(' >')
 
                 tag = get_class_crossref_tag(parent.name, parent, self.lang)
                 clazz_hierarchy.append(tag)


### PR DESCRIPTION
Fix DeprecationWarning 

Issue:
```
/auto/cafy/release/23.29.98/rhel7-23.29.98/lib/python3.6/site-packages/yangkit/models/cisco_ios_xr/Cisco_IOS_XR_smart_license_act.py:1275
/auto/cafy/release/23.29.98/rhel7-23.29.98/lib/python3.6/site-packages/yangkit/models/cisco_ios_xr/Cisco_IOS_XR_smart_license_act.py:1275:DeprecationWarning:invalidescapesequence\-
"""

/auto/cafy/release/23.29.98/rhel7-23.29.98/lib/python3.6/site-packages/yangkit/models/cisco_ios_xr/Cisco_IOS_XR_smart_license_act.py:1463
/auto/cafy/release/23.29.98/rhel7-23.29.98/lib/python3.6/site-packages/yangkit/models/cisco_ios_xr/Cisco_IOS_XR_smart_license_act.py:1463:DeprecationWarning:invalidescapesequence\:
"""
```

Updated Doc String Example :    
```
"""
    De-register. This will immediately de-register the device.
    If state:operational-mode=opr-mode-reporting then this will return
    notsupported in output:return-code
    
    .. attribute:: output
    
        **type**:  :py:class:`Output<yangkit.models.cisco_ios_xr.Cisco_IOS_XR_smart_license_act.DeRegister.Output>`
    
    """
            """
            Contains the overall status of operation and error code
            
            .. attribute:: operation_status
            
                Status of operation: Success or Failure
            
                **type**:  :py:class:`OperationStatusEnum<yangkit.models.cisco_ios_xr.Cisco_IOS_XR_smart_license_act.OperationStatusEnum>`
            
            .. attribute:: return_code
            
                The return code
            
                **type**:  :py:class:`ErrorEnum<yangkit.models.cisco_ios_xr.Cisco_IOS_XR_smart_license_act.ErrorEnum>`
            
            """
```

Older Generated Doc-Strings :    
```
"""
    De\-register. This will immediately de\-register the device.
    If state\:operational\-mode=opr\-mode\-reporting then this will return
    notsupported in output\:return\-code
    
    .. attribute:: output
    
        **type**:  :py:class:`Output<yangkit.models.cisco_ios_xr.Cisco_IOS_XR_smart_license_act.DeRegister.Output>`
    
    """
            """
            Contains the overall status of operation and error code
            
            .. attribute:: operation_status
            
                Status of operation\: Success or Failure
            
                **type**:  :py:class:`OperationStatusEnum<yangkit.models.cisco_ios_xr.Cisco_IOS_XR_smart_license_act.OperationStatusEnum>`
            
            .. attribute:: return_code
            
                The return code
            
                **type**:  :py:class:`ErrorEnum<yangkit.models.cisco_ios_xr.Cisco_IOS_XR_smart_license_act.ErrorEnum>`
            
            """
```
Test Logs:
```
Writing yangkit-models-cisco-ios-xr-7.11.1/setup.cfg
creating dist
Creating tar archive
removing 'yangkit-models-cisco-ios-xr-7.11.1' (and everything under it)

Successfully created source distribution

=================================================
Successfully generated Python Yangkit cisco-ios-xr bundle package at /auto/cafy/085_cafykit/test_packages
Please refer to the README for information on how to install the package in your environment

Code generation completed successfully!  Manual installation required!

Total time taken: 6 minutes 51 seconds

(model_venv) [jhanm@sjc-ads-1025 api_generator]$ 
```