### PR TITLE
Encode - Multiple Entity Objects

### DIFF
--- a/examples/multi_model_usage_config_example.py
+++ b/examples/multi_model_usage_config_example.py
@@ -21,6 +21,7 @@ ncclient_manager = manager.connect(host=router_info["host"],
                                    hostkey_verify=False,
                                    look_for_keys=False,
                                    allow_agent=False)
+config_list = []
 
 # Set Interface Config
 interface = {"interface_name": "FourHundredGigE0/0/0/0", "address": "1.1.1.1", "netmask": "255.0.0.0"}
@@ -29,28 +30,20 @@ ifcfg.interface_name = interface["interface_name"]
 ifcfg.ipv4.addresses.address = ifcfg.ipv4.addresses.Address()
 ifcfg.ipv4.addresses.address.address = interface["address"]
 ifcfg.ipv4.addresses.address.netmask = interface["netmask"]
-request_payload = Codec.encode(entity=ifcfg, encoding="XML", optype="create")
-print(request_payload)
-config_response = ncclient_manager.edit_config(target="candidate", config=request_payload)
-print(config_response)
-commit_response = ncclient_manager.commit()
-print(commit_response)
+config_list.append(ifcfg)
 
 # Set Segment Routing Config
 srcfg = Cisco_IOS_XR_um_segment_routing_cfg.SegmentRouting.GlobalBlock()
 srcfg.lower_bound = int(20000)
 srcfg.upper_bound = int(21000)
-request_payload = Codec.encode(entity=srcfg, encoding="XML", optype="create")
-print(request_payload)
-config_response = ncclient_manager.edit_config(target="candidate", config=request_payload)
-print(config_response)
-commit_response = ncclient_manager.commit()
-print(commit_response)
+config_list.append(srcfg)
 
 # Set GRPC Config
 grpccfg = Cisco_IOS_XR_um_grpc_cfg.Grpc()
 grpccfg.port = int(57400)
-request_payload = Codec.encode(entity=grpccfg, encoding="XML", optype="create")
+config_list.append(grpccfg)
+
+request_payload = Codec.encode(entity=config_list, encoding="XML", optype="create")
 print(request_payload)
 config_response = ncclient_manager.edit_config(target="candidate", config=request_payload)
 print(config_response)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 from yangkit.__version__ import __version__
 
 INSTALL_REQUIREMENTS = [
-    'lxml==4.9.3',
+    'lxml==3.4.4',
     'pyang==2.5.3',
     'Jinja2==3.0.3'
 ]


### PR DESCRIPTION
Updated Example : Encode takes multiple objects together, give one payload which we configure just once.

Test Logs -
```
(rhel7-23.34.90) [jhanm@sjc-ads-1025 examples]$ python multi_model_usage_config_example.py 
<config>
  <interfaces xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-interface-cfg">
    <interface>
      <interface-name>FourHundredGigE0/0/0/0</interface-name>
      <ipv4>
        <addresses xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-ip-address-cfg">
          <address>
            <address>1.1.1.1</address>
            <netmask>255.0.0.0</netmask>
          </address>
        </addresses>
      </ipv4>
    </interface>
  </interfaces>
  <segment-routing xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-segment-routing-cfg">
    <global-block>
      <lower-bound>20000</lower-bound>
      <upper-bound>21000</upper-bound>
    </global-block>
  </segment-routing>
  <grpc xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-grpc-cfg">
    <port>57400</port>
  </grpc>
</config>

<?xml version="1.0"?>
<rpc-reply message-id="urn:uuid:a9857101-1051-4b87-9d8c-3f9dd05c9111" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
 <ok/>
</rpc-reply>

<?xml version="1.0"?>
<rpc-reply message-id="urn:uuid:e8115f04-f9e7-402c-992f-779838ddb0cd" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
 <ok/>
</rpc-reply>

(rhel7-23.34.90) [jhanm@sjc-ads-1025 examples]$ 
(rhel7-23.34.90) [jhanm@sjc-ads-1025 examples]$ 
```