### PR TITLE
Don't pin dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@ from setuptools import setup, find_packages
 from yangkit.__version__ import __version__
 
 INSTALL_REQUIREMENTS = [
-    'lxml==3.4.4',
-    'pyang==2.5.3',
-    'Jinja2==3.0.3'
+    'lxml',
+    'pyang',
+    'Jinja2'
 ]
 
 setup(


### PR DESCRIPTION
As per https://packaging.python.org/en/latest/discussions/install-requires-vs-requirements/#id5
> It is not considered best practice to use `install_requires` to pin dependencies to specific versions, or to specify sub-dependencies (i.e. dependencies of your dependencies). This is overly-restrictive, and prevents the user from gaining the benefit of dependency upgrades.