### PR TITLE
Json Encoder/Decoder Examples

### DIFF
--- a/examples/json_multi_model_usage_config_example.py
+++ b/examples/json_multi_model_usage_config_example.py
@@ -1,0 +1,49 @@
+from yangkit.models.cisco_ios_xr import openconfig_system
+from yangkit.models.cisco_ios_xr import openconfig_system_logging
+from yangkit.models.cisco_ios_xr import openconfig_lacp
+
+from yangkit.codec import Codec
+
+# PYGNMI is a separate package and needs to be installed via pip
+import pygnmi.client
+
+router_info = {
+    "host": "172.26.228.76",
+    "port": "63810",
+    "username": "cafyauto",
+    "password": "cisco123"
+}
+
+gnmiclient = pygnmi.client.gNMIclient(target=(router_info["host"], router_info["port"]), username=router_info["username"],
+                                                   password=router_info["password"], insecure=True,
+                                                   path_cert=None, override=None, debug=True)
+
+gnmiclient.connect()
+
+config_list = []
+
+# Set NTP Config
+ntp = openconfig_system.System.Ntp()
+ntp.config.enabled = True
+ntp.config.enable_ntp_auth = True
+config_list.append(ntp)
+
+# Set Syslog Config
+remote_servers = openconfig_system.System.Logging.RemoteServers()
+remote_server = remote_servers.RemoteServer()
+remote_server.host = '192.168.1.112'
+remote_server.config.host = '192.168.1.112'
+remote_server.config.remote_port = 33033
+remote_servers.remote_server.append(remote_server)
+config_list.append(remote_servers)
+
+# Set LACP Config
+lacp_config = openconfig_lacp.Lacp.Config()
+lacp_config.system_priority = int(100)
+config_list.append(lacp_config)
+
+
+path_val, delete_paths = Codec.encode(entity=config_list, encoding="JSON", optype="update")
+response = gnmiclient.set(update=path_val, delete=delete_paths, replace=None, 
+                                            prefix=None, target=None, encoding="json_ietf")
+print(response)

--- a/examples/json_read_example.py
+++ b/examples/json_read_example.py
@@ -1,0 +1,30 @@
+from yangkit.models.cisco_ios_xr import openconfig_system
+from yangkit.models.cisco_ios_xr import openconfig_system_logging
+from yangkit.models.cisco_ios_xr import openconfig_lacp
+
+from yangkit.codec import Codec
+
+# PYGNMI is a separate package and needs to be installed via pip
+import pygnmi.client
+
+router_info = {
+    "host": "172.26.228.76",
+    "port": "63810",
+    "username": "cafyauto",
+    "password": "cisco123"
+}
+
+gnmiclient = pygnmi.client.gNMIclient(target=(router_info["host"], router_info["port"]), username=router_info["username"],
+                                                   password=router_info["password"], insecure=True,
+                                                   path_cert=None, override=None, debug=True)
+
+gnmiclient.connect()
+
+# Read NTP Config
+ntp = openconfig_system.System.Ntp()
+path = Codec.encode(entity=ntp, encoding="JSON", optype="read")
+response_payload = gnmiclient.get(prefix="openconfig://", path=[path], target=None, encoding='json_ietf', datatype='all')
+response_object = Codec.decode(payload=response_payload, model=ntp, encoding="JSON")
+print(response_object)
+print(response_object.config.enabled)
+print(response_object.config.enable_ntp_auth)


### PR DESCRIPTION
Json Encoder/Decoder Examples

- Config Example
- Read Example

Config Test Logs - 

```
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


gNMI request
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
prefix {
}
update {
  path {
    origin: "openconfig-system"
    elem {
      name: "system"
    }
    elem {
      name: "ntp"
    }
  }
  val {
    json_ietf_val: "{\"config\": {\"enabled\": \"true\", \"enable-ntp-auth\": \"true\"}}"
  }
}
update {
  path {
    origin: "openconfig-system"
    elem {
      name: "system"
    }
    elem {
      name: "logging"
    }
    elem {
      name: "remote-servers"
    }
  }
  val {
    json_ietf_val: "{\"remote-server\": [{\"host\": \"192.168.1.112\", \"config\": {\"host\": \"192.168.1.112\", \"remote-port\": \"33033\"}}]}"
  }
}
update {
  path {
    origin: "openconfig-lacp"
    elem {
      name: "lacp"
    }
    elem {
      name: "config"
    }
  }
  val {
    json_ietf_val: "{\"system-priority\": \"100\"}"
  }
}

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


gNMI response
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
prefix {
}
response {
  path {
    origin: "openconfig-system"
    elem {
      name: "system"
    }
    elem {
      name: "ntp"
    }
  }
  op: UPDATE
}
response {
  path {
    origin: "openconfig-system"
    elem {
      name: "system"
    }
    elem {
      name: "logging"
    }
    elem {
      name: "remote-servers"
    }
  }
  op: UPDATE
}
response {
  path {
    origin: "openconfig-lacp"
    elem {
      name: "lacp"
    }
    elem {
      name: "config"
    }
  }
  op: UPDATE
}
message {
}
timestamp: 1693900187535349825

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


{'timestamp': 1693900187535349825, 'prefix': None, 'response': [{'path': 'system/ntp', 'op': 'UPDATE'}, {'path': 'system/logging/remote-servers', 'op': 'UPDATE'}, {'path': 'lacp/config', 'op': 'UPDATE'}]}
(rhel7-23.35.11) [jhanm@sjc-ads-1025 examples]$ 

```

Read Test Logs - 

```
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


gNMI request
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
prefix {
  origin: "openconfig"
}
path {
  origin: "openconfig-system"
  elem {
    name: "system"
  }
  elem {
    name: "ntp"
  }
}
encoding: JSON_IETF

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


gNMI response
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
notification {
  timestamp: 1693900196891824664
  update {
    path {
      origin: "openconfig"
      elem {
        name: "system"
      }
      elem {
        name: "ntp"
      }
    }
    val {
      json_ietf_val: "{\n \"state\": {\n  \"enabled\": true,\n  \"enable-ntp-auth\": true\n },\n \"config\": {\n  \"enabled\": true,\n  \"enable-ntp-auth\": true\n }\n}\n"
    }
  }
}
error {
}

-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


yangkit.models.cisco_ios_xr.openconfig_system.Ntp
True
True
(rhel7-23.35.11) [jhanm@sjc-ads-1025 examples]$ 
```

