### PR TITLE
Fix for Leaf List XML Encoder

### DIFF
--- a/yangkit/codec/xml_encoder.py
+++ b/yangkit/codec/xml_encoder.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from lxml import etree
 from yangkit.utilities.logger import log
@@ -204,6 +205,15 @@ class XmlEncoder(object):
             nsmap['idx'] = leaf_data.name_space
             if leaf_data.is_set and leaf_data.value.startswith(leaf_data.name_space_prefix):
                 leaf_data.value = leaf_data.value.replace(leaf_data.name_space_prefix, 'idx')
+
+        # Needed only for leaf-list types because get_name_leafdata for YLeafList provides
+        # data in format {leaf_name_data[0]}[.="{val}"]'. ex: 'packagename[.="xr-rsvp-te"]'
+        if leaf_data.is_set:
+            match = re.search(r'\[.="', leaf_name)
+            if match:
+                span = match.span()
+                leaf_data.value = leaf_name[span[1]:-2]
+                leaf_name = leaf_name[:span[0]]
 
         leaf_ele = etree.Element(leaf_name, nsmap=nsmap)
         if leaf_data.is_set:


### PR DESCRIPTION
For leaf list XML encoding, leaf_name itself contains the name as well data. This needs to be split up.
This was missing for xml encoding but present for json encoding @ https://github.com/yang-infra/yangkit/blob/86f6f8042c523fa8478ee76dd66f6538a603b246/yangkit/codec/json_encoder.py#L139

Added the same logic here.

```
# Regular Leaf
(Pdb) leaf_name
'source-type'
(Pdb) leaf_data
<yangkit.types.types.LeafData object at 0x2b4ea98885c0>
(Pdb) vars(leaf_data)
{'value': 'tar', 'yfilter': <YFilter.not_set: 'not_set'>, 'is_set': True, 'name_space': '', 'name_space_prefix': ''}

# Leaf List
(Pdb) leaf_name
'packagename[.="xr-rsvp-te"]'
(Pdb) vars(leaf_data)
{'value': '', 'yfilter': <YFilter.not_set: 'not_set'>, 'is_set': True, 'name_space': '', 'name_space_prefix': ''}
(Pdb) 

