### PR TITLE
Version Check Based on Python Version - Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,17 @@
+import sys
 from setuptools import setup, find_packages
 
 from yangkit.__version__ import __version__
 
 INSTALL_REQUIREMENTS = [
-    'lxml==3.4.4',
     'pyang==2.5.3',
     'Jinja2==3.0.3'
 ]
+
+if sys.version.lower().startswith('3.11'):
+    INSTALL_REQUIREMENTS.append('lxml==4.9.3')
+else:
+     INSTALL_REQUIREMENTS.append('lxml==3.4.4') 
 
 setup(
     name='yangkit',


### PR DESCRIPTION
Nishant Suggested this approach - Version Check Based on Python Version

Test Logs:
```
(rhel8-23.50.10) [jhanm@sjc-ads-2280 rhel8-23.50.10]$ python
Python 3.11.4 (main, Dec  8 2023, 01:42:55) [GCC 8.5.0 20210514 (Red Hat 8.5.0-10)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
>>> import sys
>>> 
>>> print(sys.version.lower())
3.11.4 (main, dec  8 2023, 01:42:55) [gcc 8.5.0 20210514 (red hat 8.5.0-10)]
>>> 
>>> exit()
(rhel8-23.50.10) [jhanm@sjc-ads-2280 rhel8-23.50.10]$ 
(rhel8-23.50.10) [jhanm@sjc-ads-2280 rhel8-23.50.10]$ deactivate
[jhanm@sjc-ads-2280 rhel8-23.50.10]$ cd ..
[jhanm@sjc-ads-2280 23.50.10]$ ls
cafyap  cafykit  exec  exec8  rhel7  rhel7-23.50.10  rhel8  rhel8-23.50.10  star  star_profiles
[jhanm@sjc-ads-2280 23.50.10]$ 
[jhanm@sjc-ads-2280 23.50.10]$ cd rhel7-23.50.10/
[jhanm@sjc-ads-2280 rhel7-23.50.10]$ ls
bin  etc  include  lib  lib64  pip-selfcheck.json  pyvenv.cfg  share  src
[jhanm@sjc-ads-2280 rhel7-23.50.10]$ 
[jhanm@sjc-ads-2280 rhel7-23.50.10]$ source bin/activate
(rhel7-23.50.10) [jhanm@sjc-ads-2280 rhel7-23.50.10]$ 
(rhel7-23.50.10) [jhanm@sjc-ads-2280 rhel7-23.50.10]$ python
Python 3.6.7 (v3.6.7:6ec5cf2, Oct 24 2018, 15:53:56) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-16)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 
>>> import sys
>>> 
>>> print(sys.version.lower())
3.6.7 (v3.6.7:6ec5cf2, oct 24 2018, 15:53:56) 
[gcc 4.8.5 20150623 (red hat 4.8.5-16)]
>>> 
>>> exit()
(rhel7-23.50.10) [jhanm@sjc-ads-2280 rhel7-23.50.10]$ 
```

The Python Environments are already tested with these Package Version in both Python 3.6.7 & 3.11.4 Cafykit Releases. 