### PR TITLE
Draft PR : Multi Threading

### DIFF
--- a/api_generator/yang_generator/printer/python/python_bindings_printer.py
+++ b/api_generator/yang_generator/printer/python/python_bindings_printer.py
@@ -5,6 +5,7 @@
 import os
 import shutil
 from distutils import dir_util
+from concurrent.futures import ThreadPoolExecutor
 
 from yang_generator.api_model import Bits, Class, Enum, Package, get_property_name
 from yang_generator.common import get_rst_file_name
@@ -48,8 +49,9 @@ class PythonBindingsPrinter(LanguageBindingsPrinter):
         only_modules = [package.stmt for package in self.packages]
         size = len(only_modules)
 
-        for index, package in enumerate(self.packages):
-            self._print_module(index, package, size)
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            for index, package in enumerate(self.packages):
+                job = executor.submit(lambda p : self._print_module(*p), [index, package, size])
 
     def _print_module(self, index, package, size):
         print('Processing %d of %d %s' % (index + 1, size, package.stmt.pos.ref))


### PR DESCRIPTION
Multi Threading
```
cd /ws/jhanm-sjc/yang-kit/yangkit/api_generator
source /ws/jhanm-sjc/yang-kit/yangkit/yangkit_venv/bin/activate <Yangkit Env>
./generate.py --bundle /auto/cafy/Yang/bundle.json --output-directory /auto/cafy/Yang/out -v -i
```

Resulting in Segmentation fault (core dumped):
```
Created models archive: /auto/cafy/Yang/out/cisco_ios_xr-bundle/cisco_ios_xr@24.2.1.tar.gz
Processing 1 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/CISCO-ENTITY-FRU-CONTROL-MIB.yang
    Printing python module /auto/cafy/Yang/out/cisco_ios_xr-bundle/yangkit/models/cisco_ios_xr/CISCO_ENTITY_FRU_CONTROL_MIB.py
Processing 2 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-8000-fib-platform-cfg.yang
Processing 3 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-8000-lpts-oper.yang
    Printing python module /auto/cafy/Yang/out/cisco_ios_xr-bundle/yangkit/models/cisco_ios_xr/Cisco_IOS_XR_8000_fib_platform_cfg.py
    Printing python module /auto/cafy/Yang/out/cisco_ios_xr-bundle/yangkit/models/cisco_ios_xr/Cisco_IOS_XR_8000_lpts_oper.py
Processing 4 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-8000-lpts-oper-sub1.yang
    Skipping module, because it does not contain top level containers
Processing 5 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-8000-platforms-npu-evict-voq-buff-oper.yang
    Skipping module, because it does not contain top level containers
Processing 6 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-8000-platforms-npu-evict-voq-buff-oper-sub1.yang
    Skipping module, because it does not contain top level containers
Processing 7 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-8000-platforms-npu-memory-oper.yang
    Skipping module, because it does not contain top level containers
Processing 8 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-8000-platforms-npu-memory-oper-sub1.yang
    Skipping module, because it does not contain top level containers
Processing 9 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-8000-platforms-npu-resources-oper.yang
    Printing python module /auto/cafy/Yang/out/cisco_ios_xr-bundle/yangkit/models/cisco_ios_xr/Cisco_IOS_XR_8000_platforms_npu_resources_oper.py
Processing 10 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-8000-platforms-npu-resources-oper-sub1.yang
    Skipping module, because it does not contain top level containers
Processing 11 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-8000-qos-oper.yang
    Printing python module /auto/cafy/Yang/out/cisco_ios_xr-bundle/yangkit/models/cisco_ios_xr/Cisco_IOS_XR_8000_qos_oper.py
Processing 12 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-8000-qos-oper-sub1.yang
    Skipping module, because it does not contain top level containers
Processing 13 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-8000-qos-oper-sub2.yang
    Skipping module, because it does not contain top level containers
Processing 14 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-Ethernet-SPAN-act.yang
Processing 15 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-Ethernet-SPAN-cfg.yang
    Printing python module /auto/cafy/Yang/out/cisco_ios_xr-bundle/yangkit/models/cisco_ios_xr/Cisco_IOS_XR_Ethernet_SPAN_act.py
    Printing python module /auto/cafy/Yang/out/cisco_ios_xr-bundle/yangkit/models/cisco_ios_xr/Cisco_IOS_XR_Ethernet_SPAN_cfg.py
Processing 16 of 1945 /auto/cafy/Yang/out/.cache/models/cisco_ios_xr@24.2.1/Cisco-IOS-XR-Ethernet-SPAN-datatypes.yang
Segmentation fault (core dumped)
(yangkit_venv) [jhanm@sjc-ads-2280 api_generator]$ 
```