### PR TITLE
Fix Decoder - Action RPC

### DIFF
--- a/yangkit/codec/xml_decoder.py
+++ b/yangkit/codec/xml_decoder.py
@@ -101,7 +101,7 @@ class XmlDecoder(object):
             qual_node = etree.QName(child_node)
             namespace, yname = qual_node.namespace, qual_node.localname
 
-            if namespace != root_namespace:
+            if root_namespace and namespace != root_namespace:
                 for name_space_prefix, name_space in bundle_yang_ns.NAMESPACE_LOOKUP.items():
                     if name_space == namespace:
                         yname = f"{name_space_prefix}:{yname}"


### PR DESCRIPTION
Problem - For Action RPC Decoder (It's returning none Value even though the RPC Response has a Value.)

```
(Pdb) response_object
<yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.InstallPackageRemove object at 0x7fa11dde30f0>
(Pdb) response_object.output
<yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.InstallPackageRemove.Output object at 0x7fa11dde3080>
(Pdb) response_object.output.__dict__
{'parent': <yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.InstallPackageRemove object at 0x7fa11dde30f0>, 'yang_name': 'output', 'yang_parent_name': 'install-package-remove', 'yfilter': <YFilter.not_set: 'not_set'>, 'is_presence_container': False, 'is_top_level_class': False, 'has_list_ancestor': False, 'ignore_validation': False, 'ylist_key_names': [], '_is_frozen': True, 'ylist_key': None, '_logger': <Logger yangkit (Warning-)>, '_children_name_map': OrderedDict(), '_child_classes': OrderedDict(), '_leafs': OrderedDict([('op_id', (, ['str']))]), '_segment_path': <function InstallPackageRemove.Output.__init__.<locals>.<lambda> at 0x7fa11dc017b8>, '_absolute_path': <function InstallPackageRemove.Output.__init__.<locals>.<lambda> at 0x7fa11dc01840>, '_python_type_validation_enabled': False, 'op_id': None}
(Pdb) response_object.output.op_id
```
Root Cause - Here, it's entering this block of code as for action rpc response, the Root Namespace is None. So, the Root Namespace does not matched with the Namespace Value. So, the yname is getting updated in such cases - From 'op-id' to 'Cisco-IOS-XR-install-augmented-act:op-id'. So, while setting entity.set_value for this yname, the value is set to None.

https://github.com/yang-infra/yangkit/blob/main/yangkit/codec/xml_decoder.py#L104

Debugging Logs:
```
>>> installobj.install_packages_remove(["12"])
-Info-----2024-02-09T04-30-05.673[MainThread][InstallThinXrYdk]> performing install package remove for pacakges ['12']
-Info-----2024-02-09T04-30-05.674[MainThread][ncclient_connection]> Operation: action. Request: 
<install-package-remove xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-install-augmented-act">
  <packages>
    <packagename>12</packagename>
  </packages>
</install-package-remove>

-Info-----2024-02-09T04-30-05.781[MainThread][Timer]> Action Operation took 0.11 s
-Info-----2024-02-09T04-30-05.782[MainThread][ncclient_connection]> Action Operation Response:
<?xml version="1.0"?>
<rpc-reply message-id="urn:uuid:a82df0d5-9eef-47ca-b387-a5636f408eda" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
 <op-id xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-install-augmented-act">1.1.9</op-id>
</rpc-reply>

Output -->
<Element output at 0x7f8f34374d00>
Model Output -->
yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.Output
Root -> 
<Element output at 0x7f8f34374d00>
Entity -> 
yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.Output
Qual Root -> 
output
Root Namespace -> 
None
Bundle Yang NS -> 
<module 'yangkit.models.cisco_ios_xr._yang_ns' from '/auto/cafy/Python_Upgrade/311_env/lib/python3.11/site-packages/yangkit/models/cisco_ios_xr/_yang_ns.py'>
Child Node -> 
<Element {http://cisco.com/ns/yang/Cisco-IOS-XR-install-augmented-act}op-id at 0x7f8f36aecf40>
Child Qual Node ->
{http://cisco.com/ns/yang/Cisco-IOS-XR-install-augmented-act}op-id
namespace -> 
http://cisco.com/ns/yang/Cisco-IOS-XR-install-augmented-act
yname -> 
op-id
namespace -> 
http://cisco.com/ns/yang/Cisco-IOS-XR-install-augmented-act
root_namespace -> 
None
> /auto/cafy/Python_Upgrade/311_env/lib/python3.11/site-packages/yangkit/codec/xml_decoder.py(142)_decode_helper()
-> print("CN Text -> ")
(Pdb) yname
'Cisco-IOS-XR-install-augmented-act:op-id'
(Pdb) entity
<yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.InstallPackageRemove.Output object at 0x7f8f343b9650>
(Pdb) 
(Pdb) entity.__dict__
{'parent': <yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.InstallPackageRemove object at 0x7f8f36b0ebd0>, 'yang_name': 'output', 'yang_parent_name': 'install-package-remove', 'yfilter': <YFilter.not_set: 'not_set'>, 'is_presence_container': False, 'is_top_level_class': False, 'has_list_ancestor': False, 'ignore_validation': False, 'ylist_key_names': [], '_is_frozen': True, 'ylist_key': None, '_logger': <Logger yangkit (Warning-)>, '_children_name_map': OrderedDict(), '_child_classes': OrderedDict(), '_leafs': OrderedDict([('op_id', (, ['str']))]), '_segment_path': <function InstallPackageRemove.Output.__init__.<locals>.<lambda> at 0x7f8f343d0cc0>, '_absolute_path': <function InstallPackageRemove.Output.__init__.<locals>.<lambda> at 0x7f8f343d09a0>, '_python_type_validation_enabled': False, 'op_id': None}
(Pdb) 
(Pdb) entity._leafs
OrderedDict([('op_id', (, ['str']))])
(Pdb) yname = 'op_id'
(Pdb) 
(Pdb) entity.set_value(yname, child_node.text)
(Pdb) entity.__dict__
{'parent': <yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.InstallPackageRemove object at 0x7f8f36b0ebd0>, 'yang_name': 'output', 'yang_parent_name': 'install-package-remove', 'yfilter': <YFilter.not_set: 'not_set'>, 'is_presence_container': False, 'is_top_level_class': False, 'has_list_ancestor': False, 'ignore_validation': False, 'ylist_key_names': [], '_is_frozen': True, 'ylist_key': None, '_logger': <Logger yangkit (Warning-)>, '_children_name_map': OrderedDict(), '_child_classes': OrderedDict(), '_leafs': OrderedDict([('op_id', (, ['str']))]), '_segment_path': <function InstallPackageRemove.Output.__init__.<locals>.<lambda> at 0x7f8f343d0cc0>, '_absolute_path': <function InstallPackageRemove.Output.__init__.<locals>.<lambda> at 0x7f8f343d09a0>, '_python_type_validation_enabled': False, 'op_id': None}
(Pdb) 
(Pdb) yname = 'op-id'
(Pdb) 
(Pdb) entity.set_value(yname, child_node.text)
(Pdb) 
(Pdb) entity.__dict__
{'parent': <yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.InstallPackageRemove object at 0x7f8f36b0ebd0>, 'yang_name': 'output', 'yang_parent_name': 'install-package-remove', 'yfilter': <YFilter.not_set: 'not_set'>, 'is_presence_container': False, 'is_top_level_class': False, 'has_list_ancestor': False, 'ignore_validation': False, 'ylist_key_names': [], '_is_frozen': True, 'ylist_key': None, '_logger': <Logger yangkit (Warning-)>, '_children_name_map': OrderedDict(), '_child_classes': OrderedDict(), '_leafs': OrderedDict([('op_id', (, ['str']))]), '_segment_path': <function InstallPackageRemove.Output.__init__.<locals>.<lambda> at 0x7f8f343d0cc0>, '_absolute_path': <function InstallPackageRemove.Output.__init__.<locals>.<lambda> at 0x7f8f343d09a0>, '_python_type_validation_enabled': False, 'op_id': '1.1.9'}
(Pdb) 
{'parent': <yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.InstallPackageRemove object at 0x7f8f36b0ebd0>, 'yang_name': 'output', 'yang_parent_name': 'install-package-remove', 'yfilter': <YFilter.not_set: 'not_set'>, 'is_presence_container': False, 'is_top_level_class': False, 'has_list_ancestor': False, 'ignore_validation': False, 'ylist_key_names': [], '_is_frozen': True, 'ylist_key': None, '_logger': <Logger yangkit (Warning-)>, '_children_name_map': OrderedDict(), '_child_classes': OrderedDict(), '_leafs': OrderedDict([('op_id', (, ['str']))]), '_segment_path': <function InstallPackageRemove.Output.__init__.<locals>.<lambda> at 0x7f8f343d0cc0>, '_absolute_path': <function InstallPackageRemove.Output.__init__.<locals>.<lambda> at 0x7f8f343d09a0>, '_python_type_validation_enabled': False, 'op_id': '1.1.9'}
(Pdb) yname = 'Cisco-IOS-XR-install-augmented-act:op-id'
(Pdb) 
(Pdb) 
(Pdb) type(entity)
<class 'yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.InstallPackageRemove.Output'>
(Pdb) 
(Pdb) c
CN Text -> 
1.1.9
entity -> 
yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.Output
{'parent': <yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.InstallPackageRemove object at 0x7f8f36b0ebd0>, 'yang_name': 'output', 'yang_parent_name': 'install-package-remove', 'yfilter': <YFilter.not_set: 'not_set'>, 'is_presence_container': False, 'is_top_level_class': False, 'has_list_ancestor': False, 'ignore_validation': False, 'ylist_key_names': [], '_is_frozen': True, 'ylist_key': None, '_logger': <Logger yangkit (Warning-)>, '_children_name_map': OrderedDict(), '_child_classes': OrderedDict(), '_leafs': OrderedDict([('op_id', (, ['str']))]), '_segment_path': <function InstallPackageRemove.Output.__init__.<locals>.<lambda> at 0x7f8f343d0cc0>, '_absolute_path': <function InstallPackageRemove.Output.__init__.<locals>.<lambda> at 0x7f8f343d09a0>, '_python_type_validation_enabled': False, 'op_id': '1.1.9'}
attr -> 
None
child -> 
None
Model Output -->
yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.Output
{'parent': None, 'yang_name': 'install-package-remove', 'yang_parent_name': 'Cisco-IOS-XR-install-augmented-act', 'yfilter': <YFilter.not_set: 'not_set'>, 'is_presence_container': False, 'is_top_level_class': True, 'has_list_ancestor': False, 'ignore_validation': False, 'ylist_key_names': [], '_is_frozen': True, 'ylist_key': None, '_logger': <Logger yangkit (Warning-)>, '_children_name_map': OrderedDict([('input', 'input'), ('output', 'output')]), '_child_classes': OrderedDict(), '_leafs': OrderedDict(), '_segment_path': <function InstallPackageRemove.__init__.<locals>.<lambda> at 0x7f8f343d0c20>, '_absolute_path': <function Entity.__init__.<locals>.<lambda> at 0x7f8f343d07c0>, '_python_type_validation_enabled': False, '_top_entity': None, 'input': <yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.InstallPackageRemove.Input object at 0x7f8f36ad1ed0>, 'output': <yangkit.models.cisco_ios_xr.Cisco_IOS_XR_install_augmented_act.InstallPackageRemove.Output object at 0x7f8f343b9650>}

```

Fix - Added an addition if Root Namespace check, to handle such scenarios. 

TZ - https://techzone.cisco.com/t5/IOS-XR-PI-CQE-INFRA-Eng/YDK-Output-op-id-returning-null-value-for-rpc-reply-for-install/td-p/11252170

Test Logs: http://allure.cisco.com/ws/jhanm-sjc/cafykit/work/archive/install_test_20240209-054617_p862284/reports/index.html
