### PR TITLE
Relax the install requirements, don't specify versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ venv
 *.egg
 .cache
 .idea/
+build/

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,12 @@
-import sys
 from setuptools import setup, find_packages
 
 from yangkit.__version__ import __version__
 
 INSTALL_REQUIREMENTS = [
-    'pyang==2.5.3',
-    'Jinja2==3.0.3'
+    'Jinja2',
+    'lxml',
+    'pyang',
 ]
-
-if sys.version.lower().startswith('3.11'):
-    INSTALL_REQUIREMENTS.append('lxml==4.9.3')
-else:
-     INSTALL_REQUIREMENTS.append('lxml==3.4.4') 
 
 setup(
     name='yangkit',


### PR DESCRIPTION
Currently impossible to install this package alongside package versions that do not match those specified in `setup.py` - best practice is not to fix the version when providing a package that can be installed alongside others.

https://stackoverflow.com/a/44938662
https://discuss.python.org/t/should-i-be-pinning-my-dependencies/13159/2
https://news.ycombinator.com/item?id=26217640