### PR TITLE
Update types.py

### DIFF
--- a/yangkit/types/types.py
+++ b/yangkit/types/types.py
@@ -505,7 +505,7 @@ class Entity:
 
         for seg in [child_yang_name, segment_path]:
             for name in self._children_name_map:
-                if seg == self._children_name_map[name]:
+                if seg in self._children_name_map[name]:
                     if self.__dict__[name]:
                         return name, self.__dict__[name]
 


### PR DESCRIPTION
For some yang files, extended models or other models will be added and segment path will have that model name added (for example - "Cisco-IOS-XR-openconfig-transport-line-common-ext:cisco"). In such cases, get_child_by_name fails. To accommodate that changed the if condition.